### PR TITLE
Fix: xml格式参数，请求类型bug

### DIFF
--- a/pay-java-common/src/main/java/com/egzosn/pay/common/http/ClientHttpRequest.java
+++ b/pay-java-common/src/main/java/com/egzosn/pay/common/http/ClientHttpRequest.java
@@ -38,7 +38,7 @@ import static com.egzosn.pay.common.http.UriVariables.getMapToParameters;
 public class ClientHttpRequest<T> extends HttpEntityEnclosingRequestBase implements org.apache.http.client.ResponseHandler<T> {
     protected static final Log LOG = LogFactory.getLog(ClientHttpRequest.class);
     public static final ContentType APPLICATION_FORM_URLENCODED_UTF_8 = ContentType.create("application/x-www-form-urlencoded", Consts.UTF_8);
-
+    public static final ContentType APPLICATION_XML_UTF_8 = ContentType.create("application/xml", Consts.UTF_8);
 
     /**
      * http请求方式 get pos
@@ -252,7 +252,10 @@ public class ClientHttpRequest<T> extends HttpEntityEnclosingRequestBase impleme
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Parameter : " + request);
             }
-            StringEntity entity = new StringEntity((String) request, APPLICATION_FORM_URLENCODED_UTF_8);
+            boolean isXMLString = ((String) request).startsWith("<?xml");
+            StringEntity entity = isXMLString ?
+                    new StringEntity((String) request, APPLICATION_XML_UTF_8) :
+                    new StringEntity((String) request, APPLICATION_FORM_URLENCODED_UTF_8);
             setEntity(entity);
         } else {
             String body = JSON.toJSONString(request);


### PR DESCRIPTION
这里不加判断的话，微信沙盒测试流程中，发送xml格式的参数请求，参数会以APPLICATION_FORM_URLENCODED_UTF_8的格式发出，导致请求微信接口报错；

用“是否是<?xml开头”来判断请求字符串是否是xml有些粗糙，不过应该够用；