### PR TITLE
Could com.egzosn:pay-java-web-support:2.14.4-fix drop off redundant dependencies? 

### DIFF
--- a/pay-java-web-support/pom.xml
+++ b/pay-java-web-support/pom.xml
@@ -20,6 +20,12 @@
         <dependency>
             <groupId>com.egzosn</groupId>
             <artifactId>pay-java-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpmime</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/78527112/170037862-0f94b909-8434-4f7e-9ef6-f06f746b6c2c.png)

Hi! I found the pom file of project **_com.egzosn:pay-java-web-support:2.14.4-fix_** introduced **_11_** dependencies. However, among them, **_5_** libraries (**_45%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
commons-logging:commons-logging:jar:1.2:compile
org.apache.httpcomponents:httpmime:jar:4.5.4:compile
org.apache.httpcomponents:httpclient:jar:4.5.4:compile
commons-codec:commons-codec:jar:1.10:compile
org.apache.httpcomponents:httpcore:jar:4.4.7:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.apache.httpcomponents:httpclient:jar:4.5.4:compile_** incorporates a medium-level vulnerability SNYK-JAVA-ORGAPACHEHTTPCOMPONENTS-1048058. As such, I suggest a refactoring operation for **_com.egzosn:pay-java-web-support:2.14.4-fix_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.egzosn:pay-java-web-support:2.14.4-fix_**’s maven tests.

Best regards