### PR TITLE
fix: 金额转分，程序上进行最大值判定，避免业务方无感知造成金额不可控问题

### DIFF
--- a/pay-java-common/src/main/java/com/egzosn/pay/common/util/Util.java
+++ b/pay-java-common/src/main/java/com/egzosn/pay/common/util/Util.java
@@ -1,7 +1,10 @@
 package com.egzosn.pay.common.util;
 
+import com.egzosn.pay.common.bean.result.PayException;
+import com.egzosn.pay.common.exception.PayErrorException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.util.Collection;
 import java.util.Map;
 
@@ -590,7 +593,11 @@ public class Util {
      * @return 分的金额
      */
     public static int conversionCentAmount(BigDecimal amount) {
-        return amount.multiply(HUNDRED).setScale(0, BigDecimal.ROUND_HALF_UP).intValue();
+        final BigDecimal decimal = amount.multiply(HUNDRED).setScale(0, RoundingMode.HALF_UP);
+        if (decimal.longValue() > (long) Integer.MAX_VALUE) {
+            throw new PayErrorException(new PayException("illegal parameter", "订单金额过大"));
+        }
+        return decimal.intValue();
     }
 
     /**


### PR DESCRIPTION
金额理论上应由业务方按照实际规则进行限制，但sdk程序中由于价格入参是BigDecimal， 调用方可能会忽略实际存在的问题，从而导致实际订单金额不可控。