### PR TITLE
Bumped up the apache-commons-codec to 1.17 a non-vulnerable version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <properties>
         <revision>2.14.9</revision>
         <httpmime.version>4.5.4</httpmime.version>
+        <commons-codec.version>1.17.1</commons-codec.version>
         <log4j.version>1.2.17</log4j.version>
         <fastjson.version>1.2.83</fastjson.version>
         <zxing.version>3.3.1</zxing.version>
@@ -101,6 +102,11 @@
                 <version>${httpmime.version}</version>
             </dependency>
             <!--/httpcomponents-->
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.alibaba</groupId>
                 <artifactId>fastjson</artifactId>


### PR DESCRIPTION
Upgrades the transitive commons-codec dependency from 1.10 (pulled in via httpmime:4.5.4 → httpclient:4.5.4) to 1.17.1 by pinning it explicitly in the root pom.xml.

**Changes:**

Added <commons-codec.version>1.17.1</commons-codec.version> property in root pom.xml
Added explicit commons-codec entry in <dependencyManagement> to override the transitive version
Why: The previous transitive version (1.10) falls within the vulnerable range [,1.13). This upgrade resolves that by forcing all modules to use 1.17.1.

**Verification:**

mvn compile passes for all 12 core modules
pay-java-demo failure is pre-existing and unrelated (binary .pfx file filtering issue)